### PR TITLE
Add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,10 @@
+# Description
+A brief description of the content for the PR.
+
+# Referenced issues
+This PR resolves or references the following issues:
+- #ISSUE
+
+# Testing
+- [ ] Tested in development environment
+- [ ] Tested on the Turtlebot


### PR DESCRIPTION
This PR adds a PR template for further PRs.
The idea is to make sure that every PR has a good description and automatically closes issues if the PR has been merged to `dev`